### PR TITLE
Fix conv2D params and residual saturation

### DIFF
--- a/MobileNetV3_small/Block.sv
+++ b/MobileNetV3_small/Block.sv
@@ -314,7 +314,17 @@ module Block #(
                 for (int h = 0; h < OUT_HEIGHT; h++) begin
                     for (int w = 0; w < OUT_WIDTH; w++) begin
                         for (int c = 0; c < OUT_SIZE; c++) begin
-                            data_out[h][w][c] <= se_out[h][w][c] + shortcut_out[h][w][c];
+                            // Perform saturated addition of the residual
+                            logic signed [DATA_WIDTH:0] add_res;
+                            add_res = se_out[h][w][c] + shortcut_out[h][w][c];
+
+                            if (add_res > (2**(DATA_WIDTH-1) - 1)) begin
+                                data_out[h][w][c] <= 2**(DATA_WIDTH-1) - 1;
+                            end else if (add_res < -(2**(DATA_WIDTH-1))) begin
+                                data_out[h][w][c] <= -(2**(DATA_WIDTH-1));
+                            end else begin
+                                data_out[h][w][c] <= add_res[DATA_WIDTH-1:0];
+                            end
                         end
                     end
                 end

--- a/MobileNetV3_small/Conv2D.sv
+++ b/MobileNetV3_small/Conv2D.sv
@@ -9,7 +9,10 @@ module Conv2D #(
     parameter IN_HEIGHT = 224,
     parameter IN_WIDTH = 224,
     parameter DATA_WIDTH = 8,
-    parameter FRAC_BITS = 4
+    parameter FRAC_BITS = 4,
+    // Derived parameters declared here so they are available for port sizing
+    parameter OUT_HEIGHT = (IN_HEIGHT + 2 * PADDING - KERNEL_SIZE) / STRIDE + 1,
+    parameter OUT_WIDTH  = (IN_WIDTH  + 2 * PADDING - KERNEL_SIZE) / STRIDE + 1
 )(
     
     //-Input
@@ -26,9 +29,7 @@ module Conv2D #(
     output logic valid_out
 );
 
-    // Calculate output dimensions
-    localparam OUT_WIDTH = (IN_WIDTH + 2 * PADDING - KERNEL_SIZE) / STRIDE + 1;
-    localparam OUT_HEIGHT = (IN_HEIGHT + 2 * PADDING - KERNEL_SIZE) / STRIDE + 1;
+    // Calculate output dimensions (already defined as parameters)
 
     // Enhanced accumulator width calculation
     localparam MULT_WIDTH = DATA_WIDTH * 2;


### PR DESCRIPTION
## Summary
- avoid overflow when adding residual path in `Block.sv`
- expose Conv2D output sizes as parameters for cleaner port declarations

## Testing
- `vsim -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686abdc1cb608320a87136a5cbe9b1b3